### PR TITLE
Change error behavior

### DIFF
--- a/.changeset/new-rocks-sing.md
+++ b/.changeset/new-rocks-sing.md
@@ -1,0 +1,93 @@
+---
+"@lucadiba/satispay-client": major
+---
+
+# Breaking changes
+
+## Errors
+
+Before this change, the library returned the following object for all the Client requests:
+
+```typescript
+const paymentResponse = await satispay.payments.create({
+  flow: "MATCH_CODE",
+  amountUnit: 100,
+  currency: "EUR",
+});
+
+/**
+ * paymentResponse: {
+ *   success: true,
+ *   data: {
+ *     ...
+ *   }
+ * } | {
+ *   success: false,
+ *   error: {
+ *     ...
+ *   }
+ * }
+ */
+
+if (paymentResponse.success) {
+  const payment = paymentResponse.data;
+
+  // Save the payment id
+  const paymentId = payment.id;
+
+  // Redirect the user to the redirectUrl
+  const redirectUrl = payment.redirect_url;
+
+  // ...
+} else {
+  // Handle the error
+  const error = paymentResponse.error;
+}
+```
+
+After this change, the library will directly throw an error if the request fails.
+If the request is successful, the library will return the successful response.
+
+```typescript
+try {
+  const payment = await satispay.payments.create({
+    flow: "MATCH_CODE",
+    amountUnit: 100,
+    currency: "EUR",
+  });
+
+  // Save the payment id
+  const paymentId = payment.id;
+
+  // Redirect the user to the redirectUrl
+  const redirectUrl = payment.redirect_url;
+
+  // ...
+} catch (error) {
+  // Handle the error
+}
+```
+
+The error type `SatispayError` has been introduced. It extends the `Error` class and has the following properties:
+
+- `name: string` - The error name
+- `message: string` - The error message
+- `code: string` - The error code
+- `status: number` - The HTTP status code
+
+It is possible to check the error type using the `isSatispayError` utility function.
+If the result is true, the error type `SatispayError` is automatically inferred.
+
+```typescript
+import { SatispayError } from "@lucadiba/satispay-client";
+
+try {
+  // ...
+} catch (error) {
+  if (SatispayError.isSatispayError(error)) {
+    // The SatispayError type is automatically inferred to the error variable
+  } else {
+    // The type of the error variable is unknown
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -62,26 +62,17 @@ const satispay = new Satispay.Client({
 ### Create a payment
 
 ```typescript
-const paymentResponse = await satispay.payments.create({
+const payment = await satispay.payments.create({
   flow: "MATCH_CODE",
   amountUnit: 100,
   currency: "EUR",
 });
 
-if (paymentResponse.success) {
-  const payment = paymentResponse.data;
+// Save the payment id
+const paymentId = payment.id;
 
-  // Save the payment id
-  const paymentId = payment.id;
-
-  // Redirect the user to the redirectUrl
-  const redirectUrl = payment.redirect_url;
-
-  // ...
-} else {
-  // Handle the error
-  const error = paymentResponse.error;
-}
+// Redirect the user to the redirectUrl
+const redirectUrl = payment.redirect_url;
 ```
 
 ### Get a payment
@@ -135,6 +126,39 @@ const satispay = new Satispay.Client({
   keyId,
   privateKey,
 });
+```
+
+## Errors
+
+### Handling errors
+
+This package throws an error when the Satispay API returns an error. You can catch the error and handle it as you prefer.
+
+If the errors comes from the Satispay API, the error will be an instance of `SatispayError`. There is a utility method to check if an error is a `SatispayError`.
+
+```typescript
+import { SatispayError } from "@lucadiba/satispay-client";
+
+try {
+  await satispay.payments.create({
+    flow: "MATCH_CODE",
+    amountUnit: -100,
+    currency: "EUR",
+  });
+} catch (error) {
+  if (SatispayError.isSatispayError(error)) {
+    // The SatispayError type is automatically inferred
+    console.error({
+      message: error.message,
+      data: error.data,
+      code: error.code,
+      status: error.status,
+    });
+  } else {
+    // The type of error is unknown
+    console.error(error);
+  }
+}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <h1 align="center">Satispay Node.js client</h1>
-<h2 align="center">⚠️ This package is in beta ⚠️</h2>
 
 <p>
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white" />

--- a/src/errors/SatispayError.ts
+++ b/src/errors/SatispayError.ts
@@ -1,0 +1,31 @@
+export default class SatispayError extends Error {
+  public name = "SatispayError";
+
+  public data: unknown;
+
+  public code: string;
+
+  public status: number;
+
+  public constructor({
+    message,
+    data,
+    code,
+    status,
+  }: {
+    message: string;
+    data: unknown;
+    code: string;
+    status: number;
+  }) {
+    super(message);
+
+    this.data = data;
+    this.code = code;
+    this.status = status;
+  }
+
+  public static isSatispayError(err: unknown): err is SatispayError {
+    return err instanceof SatispayError && err.name === "SatispayError";
+  }
+}

--- a/src/errors/__tests__/SatispayError.test.ts
+++ b/src/errors/__tests__/SatispayError.test.ts
@@ -1,0 +1,35 @@
+import SatispayError from "../SatispayError";
+
+test("SatispayError", () => {
+  const error = new SatispayError({
+    message: "test-message",
+    data: { test: "data" },
+    code: "test-code",
+    status: 400,
+  });
+
+  expect(error.name).toBe("SatispayError");
+  expect(error.message).toBe("test-message");
+  expect(error.data).toEqual({ test: "data" });
+  expect(error.code).toBe("test-code");
+  expect(error.status).toBe(400);
+});
+
+describe("isSatispayError", () => {
+  test("SatispayError", () => {
+    const error = new SatispayError({
+      message: "test-message",
+      data: { test: "data" },
+      code: "test-code",
+      status: 400,
+    });
+
+    expect(SatispayError.isSatispayError(error)).toBe(true);
+  });
+
+  test("Error", () => {
+    const error = new Error("test-message");
+
+    expect(SatispayError.isSatispayError(error)).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
+import SatispayError from "./errors/SatispayError";
 import { Authentication } from "./modules/authentication";
 import { Client } from "./modules/client";
 
 const Satispay = {
   Client,
   Authentication,
+  SatispayError,
 };
 
 export default Satispay;

--- a/src/modules/client/payments/api/__tests__/create.test.ts
+++ b/src/modules/client/payments/api/__tests__/create.test.ts
@@ -92,10 +92,7 @@ test("MATCH_CODE", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });
 
 test("PRE_AUTHORIZED", async () => {
@@ -135,10 +132,7 @@ test("PRE_AUTHORIZED", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });
 
 test("REFUND", async () => {
@@ -179,10 +173,7 @@ test("REFUND", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });
 
 test("MATCH_USER", async () => {
@@ -223,8 +214,5 @@ test("MATCH_USER", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });

--- a/src/modules/client/payments/api/__tests__/get-all.test.ts
+++ b/src/modules/client/payments/api/__tests__/get-all.test.ts
@@ -86,10 +86,7 @@ test("Without parameters", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });
 
 test("With parameters", async () => {
@@ -119,8 +116,5 @@ test("With parameters", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });

--- a/src/modules/client/payments/api/__tests__/get.test.ts
+++ b/src/modules/client/payments/api/__tests__/get.test.ts
@@ -79,8 +79,5 @@ test("Get payment", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });

--- a/src/modules/client/payments/api/__tests__/update.test.ts
+++ b/src/modules/client/payments/api/__tests__/update.test.ts
@@ -83,10 +83,7 @@ test("Without amount unit", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });
 
 test("With amount unit", async () => {
@@ -119,8 +116,5 @@ test("With amount unit", async () => {
     },
   });
 
-  expect(response).toEqual({
-    success: true,
-    data: expectedReturnData,
-  });
+  expect(response).toEqual(expectedReturnData);
 });

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { Settings } from "luxon";
 
+import SatispayError from "../../errors/SatispayError";
 import { makeAuthorizedRequest, makeRequest } from "../api";
 import { TEST_PRIVATE_KEY } from "../test-utils";
 
@@ -30,10 +31,7 @@ describe("makeRequest", () => {
       data: undefined,
     });
 
-    expect(response).toEqual({
-      success: true,
-      data: { data: "data" },
-    });
+    expect(response).toEqual({ data: "data" });
   });
 
   describe("return success false and error when request is unsuccessful", () => {
@@ -42,10 +40,20 @@ describe("makeRequest", () => {
         mockedAxios.isAxiosError.mockReturnValue(true);
         mockedAxios.request.mockRejectedValueOnce({});
 
-        const response = await makeRequest({
-          method: "GET",
-          url: "https://example.com/test",
-        });
+        try {
+          await makeRequest({
+            method: "GET",
+            url: "https://example.com/test",
+          });
+          fail("Should throw");
+        } catch (err) {
+          const error = err as SatispayError;
+          expect(error.name).toBe("SatispayError");
+          expect(error.message).toBe("");
+          expect(error.data).toBeUndefined();
+          expect(error.code).toBe("UNKNOWN");
+          expect(error.status).toBe(500);
+        }
 
         expect(mockedAxios.request).toHaveBeenCalledTimes(1);
         expect(mockedAxios.request).toHaveBeenCalledWith({
@@ -53,11 +61,6 @@ describe("makeRequest", () => {
           url: "https://example.com/test",
           headers: undefined,
           data: undefined,
-        });
-
-        expect(response).toEqual({
-          success: false,
-          error: undefined,
         });
       });
 
@@ -67,10 +70,20 @@ describe("makeRequest", () => {
           response: { data: { errors: [{ detail: "detail-text" }] } },
         });
 
-        const response = await makeRequest({
-          method: "GET",
-          url: "https://example.com/test",
-        });
+        try {
+          await makeRequest({
+            method: "GET",
+            url: "https://example.com/test",
+          });
+          fail("Should throw");
+        } catch (err) {
+          const error = err as SatispayError;
+          expect(error.name).toBe("SatispayError");
+          expect(error.message).toBe("");
+          expect(error.data).toEqual({ errors: [{ detail: "detail-text" }] });
+          expect(error.code).toBe("UNKNOWN");
+          expect(error.status).toBe(500);
+        }
 
         expect(mockedAxios.request).toHaveBeenCalledTimes(1);
         expect(mockedAxios.request).toHaveBeenCalledWith({
@@ -79,13 +92,6 @@ describe("makeRequest", () => {
           headers: undefined,
           data: undefined,
         });
-
-        expect(response).toEqual({
-          success: false,
-          error: {
-            errors: [{ detail: "detail-text" }],
-          },
-        });
       });
     });
 
@@ -93,10 +99,20 @@ describe("makeRequest", () => {
       mockedAxios.isAxiosError.mockReturnValue(false);
       mockedAxios.request.mockRejectedValueOnce(new Error("Generic error"));
 
-      const response = await makeRequest({
-        method: "GET",
-        url: "https://example.com/test",
-      });
+      try {
+        await makeRequest({
+          method: "GET",
+          url: "https://example.com/test",
+        });
+        fail("Should throw");
+      } catch (err) {
+        const error = err as Error;
+        expect(error.name).toBe("Error");
+        expect(error.message).toBe("Generic error");
+        expect("data" in error).toBe(false);
+        expect("code" in error).toBe(false);
+        expect("status" in error).toBe(false);
+      }
 
       expect(mockedAxios.request).toHaveBeenCalledTimes(1);
       expect(mockedAxios.request).toHaveBeenCalledWith({
@@ -104,11 +120,6 @@ describe("makeRequest", () => {
         url: "https://example.com/test",
         headers: undefined,
         data: undefined,
-      });
-
-      expect(response).toEqual({
-        success: false,
-        error: new Error("Generic error"),
       });
     });
   });
@@ -150,10 +161,7 @@ describe("makeAuthorizedRequest", () => {
         data: undefined,
       });
 
-      expect(response).toEqual({
-        success: true,
-        data: { data: "data" },
-      });
+      expect(response).toEqual({ data: "data" });
     });
 
     test("use body with body", async () => {
@@ -196,10 +204,7 @@ describe("makeAuthorizedRequest", () => {
         },
       });
 
-      expect(response).toEqual({
-        success: true,
-        data: { data: "data" },
-      });
+      expect(response).toEqual({ data: "data" });
     });
   });
 });


### PR DESCRIPTION
Before this change, the library returned the following object for all the Client requests:

```typescript
const paymentResponse = await satispay.payments.create({
  flow: "MATCH_CODE",
  amountUnit: 100,
  currency: "EUR",
});

/**
 * paymentResponse: {
 *   success: true,
 *   data: {
 *     ...
 *   }
 * } | {
 *   success: false,
 *   error: {
 *     ...
 *   }
 * }
 */

if (paymentResponse.success) {
  const payment = paymentResponse.data;

  // Save the payment id
  const paymentId = payment.id;

  // Redirect the user to the redirectUrl
  const redirectUrl = payment.redirect_url;

  // ...
} else {
  // Handle the error
  const error = paymentResponse.error;
}
```

After this change, the library will directly throw an error if the request fails.
If the request is successful, the library will return the successful response.

```typescript
try {
  const payment = await satispay.payments.create({
    flow: "MATCH_CODE",
    amountUnit: 100,
    currency: "EUR",
  });

  // Save the payment id
  const paymentId = payment.id;

  // Redirect the user to the redirectUrl
  const redirectUrl = payment.redirect_url;

  // ...
} catch (error) {
  // Handle the error
}
```

The error type `SatispayError` has been introduced. It extends the `Error` class and has the following properties:

- `name: string` - The error name
- `message: string` - The error message
- `code: string` - The error code
- `status: number` - The HTTP status code

It is possible to check the error type using the `isSatispayError` utility function.
If the result is true, the error type `SatispayError` is automatically inferred.

```typescript
import { SatispayError } from "@lucadiba/satispay-client";

try {
  // ...
} catch (error) {
  if (SatispayError.isSatispayError(error)) {
    // The SatispayError type is automatically inferred to the error variable
  } else {
    // The type of the error variable is unknown
  }
}
```