### PR TITLE
Fix TypeScript issue in ESM

### DIFF
--- a/.changeset/new-rocks-sing.md
+++ b/.changeset/new-rocks-sing.md
@@ -1,0 +1,5 @@
+---
+"@lucadiba/satispay-client": patch
+---
+- Address type issue in ESM modules.
+- Bump dependencies

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install @lucadiba/satispay-client
 Import the package in your Node.js application:
 
 ```typescript
-import Satispay from "@lucadiba/satispay-client";
+import { Satispay } from "@lucadiba/satispay-client";
 ```
 
 ### Initialize the client
@@ -102,7 +102,7 @@ satispay.payments.update({
 The Satispay API uses an authentication method based on a RSA key pair. You can generate a new key pair using the `generateKeyPair` method:
 
 ```typescript
-import Satispay from "@lucadiba/satispay-client";
+import { Satispay } from "@lucadiba/satispay-client";
 
 const { publicKey, privateKey } =
   await Satispay.Authentication.generateKeyPair();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import SatispayError from "./errors/SatispayError";
 import { Authentication } from "./modules/authentication";
 import { Client } from "./modules/client";
 
-const Satispay = {
+export const Satispay = {
   Client,
   Authentication,
   SatispayError,


### PR DESCRIPTION
This PR fixes an issue where the library is not importable from ESM modules, due to the lack of a non-default export.